### PR TITLE
Parameterize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The purpose of kex is to provide an opinionated executor into a kubernetes container.  Traditionally, if one wanted to exec into a kubernetes container, one had to `kubectl get pods --namespace foo`, visually identify the pod of interest, copy that pod to the buffer, and then `kubectl --namespace foo exec -it <paste_buffer> bash` to exec in to the pod.  This simple utility aims to provide a namespace-specific pod selector for quick execution.
+The purpose of kex is to provide an opinionated executor into a kubernetes container.  Traditionally, if one wanted to exec into a kubernetes container, one had to `kubectl get pods --namespace foo`, visually identify the pod of interest, copy that pod to the buffer, and then `kubectl --namespace foo exec -it <paste_buffer> bash` to exec into the pod.  This simple utility aims to provide a namespace-specific pod selector for quick execution.
 
 # kex
 
@@ -26,7 +26,7 @@ OPTIONS
 
     -c, --command
         Specify an alternative exec command. Defaults to "bash"
-        
+
     -h, --help
         Show this help message
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,37 @@ The purpose of kex is to provide an opinionated executor into a kubernetes conta
 
 # kex
 
-kex is a pod exec utility.
+kex(1)
 
-```
-USAGE:
-  kex ls,list     : list the available pods
-  kex             : exec in to the first listed pod
-  kex <NUM>       : exec into a specified pod
-  kex -h,--help   : show this message
-```
+NAME
+    kex - Quick k8s pod exec utility.
+
+REQUIRES
+    kubectl(1)
+
+SYNOPSIS
+    kex [-n <NUMBER>|1] [-c <COMMAND>|bash] [OPTIONS]
+
+DESCRIPTION
+    kex is a quick kubernetes (k8s) utility to exec into a pod.
+
+OPTIONS
+    -l, --list
+        List available pods
+    -n, --number
+        Specify the pod number in the list to exec into. Default to "1"
+    -c, --command
+        Specify an alternative exec command. Defaults to "bash"
+    -h, --help
+        Show this help message
+
+SEE ALSO
+    kubectx(1), kubens(1)
 
 ### USAGE
 
 ```sh
-$ kex ls
+$ kex -l
 1           365bass-dt1nb
 2           esp-echo-546159305-mh4gq
 3           livewell-frontend-3514659123-hq60x
@@ -29,8 +46,11 @@ $ kex ls
 $ kex
 root@365bass-dt1nb:/#
 
-$ kex 5
+$ kex -n 5
 root@livewell-frontend-3514659123-wm77l:/app#
+
+$ kex -n 9 -c uname
+Linux
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -17,12 +17,16 @@ DESCRIPTION
     kex is a quick kubernetes (k8s) utility to exec into a pod.
 
 OPTIONS
+
     -l, --list
         List available pods
+
     -n, --number
         Specify the pod number in the list to exec into. Default to "1"
+
     -c, --command
         Specify an alternative exec command. Defaults to "bash"
+        
     -h, --help
         Show this help message
 

--- a/kex
+++ b/kex
@@ -42,20 +42,20 @@ SEE ALSO
 EOF
 }
 
-po_get() {
+po_list() {
   kubectl get pods -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'
 }
 
-po_list() {
-  po_get | nl
+po_number_list() {
+  po_list | nl
 }
 
-po_extract() {
-  po_get | sed -n ${NUMBER:-1}p
+po_select() {
+  po_list | sed -n ${NUMBER:-1}p
 }
 
 po_exec() {
-  kubectl exec -it $(po_extract) ${COMMAND:-bash}
+  kubectl exec -it $(po_select) ${COMMAND:-bash}
 }
 
 # Transform long options to short ones. Sick trick.
@@ -73,7 +73,7 @@ done
 
 while getopts :lhn:c: OPT; do
   case $OPT in
-    l ) po_list; exit 0;;
+    l ) po_number_list; exit 0;;
     n ) NUMBER=$OPTARG;;
     c ) COMMAND=$OPTARG;;
     h ) usage; exit 0;;

--- a/kex
+++ b/kex
@@ -1,78 +1,87 @@
 #!/bin/bash
 #
-# kex is a utility to quickly exec into a kubernetes pod.
+# See usage().
 
 [[ -n $DEBUG ]] && set -x
 
 set -eou pipefail
 IFS=$'\n\t'
 
+# We do this so the called script name variable is avilable in utility functions
+# below, in case of name change, brew alias, etc.
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+
 usage() {
-  cat <<"EOF"
-USAGE:
-  kex             : exec in to the first listed pod
-  kex -ls,--list  : list the available pods
-  kex <NUM>       : exec into a specified pod
-  kex -h,--help   : show this message
+  cat <<EOF
+${SCRIPT}(1)
+
+NAME
+    ${SCRIPT} - Quick k8s pod exec utility.
+
+REQUIRES
+    kubectl(1)
+
+SYNOPSIS
+    ${SCRIPT} [-n <NUMBER>|1] [-c <COMMAND>|bash] [OPTIONS]
+
+DESCRIPTION
+    ${SCRIPT} is a quick kubernetes (k8s) utility to exec into a pod.
+
+OPTIONS
+    -l, --list
+        List available pods
+    -n, --number
+        Specify the pod number in the list to exec into. Default to "1"
+    -c, --command
+        Specify an alternative exec command. Defaults to "bash"
+    -h, --help
+        Show this help message
+
+SEE ALSO
+    kubectx(1), kubens(1)
 EOF
 }
 
-POD_NUM=${POD_NUM:-1}
-
-pod_def(){
-  kubectl get pods -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}' | nl
-  exit 0
+po_get() {
+  kubectl get pods -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'
 }
 
-pod_default(){
-  kubectl get pods -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}' | sed -n 1p
+po_list() {
+  po_get | nl
 }
 
-kube_def_bash(){
-  kubectl exec -it $(pod_default) bash
+po_extract() {
+  po_get | sed -n ${NUMBER:-1}p
 }
 
-# Placeholder for next version when bash isn't present in the container image.
-# kube_def_sh(){
-#   kubectl exec -it $(pod_default) sh
-# }
-
-pod_select(){
-  kubectl get pods -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}' | sed -n ${POD_NUM}p
+po_exec() {
+  kubectl exec -it $(po_extract) ${COMMAND:-bash}
 }
 
-# Placeholder for next version when bash isn't present in the container image.
-# kube_exec_sh() {
-#   kubectl exec -it $(pod_select) sh
-# }
+# Transform long options to short ones. Sick trick.
+# http://stackoverflow.com/a/30026641/4096495
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--list")     set -- "$@" "-l" ;;
+    "--number")   set -- "$@" "-n" ;;
+    "--command")  set -- "$@" "-c" ;;
+    "--help")     set -- "$@" "-h" ;;
+    *)            set -- "$@" "$arg"
+  esac
+done
 
-kube_exec_bash() {
-  kubectl exec -it $(pod_select) bash
-}
+while getopts :lhn:c: OPT; do
+  case $OPT in
+    l ) po_list; exit 0;;
+    n ) NUMBER=$OPTARG;;
+    c ) COMMAND=$OPTARG;;
+    h ) usage; exit 0;;
+    \?) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+    : ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+  esac
+done
+shift $((OPTIND-1))
 
-main() {
-  if [[ "$#" -eq 0 ]]; then
-    kube_def_bash
-  elif [[ "$#" -gt 1 ]]; then
-    echo "error: too many flags" >&2
-    usage
-    exit 1
-  elif [[ "$#" -eq 1 ]]; then
-    if [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
-      usage
-      exit 0
-    elif [[ "${1}" == '-ls' || "${1}" == '--list' ]]; then
-      pod_def
-    elif [[ "${1}" =~ ^-(.*) ]]; then
-      echo "error: unrecognized flag \"${1}\"" >&2
-      usage
-      exit 1
-    fi
-    if [[ "${1}" ]]; then
-      POD_NUM=${1}
-    kube_exec_bash
-    fi
-  fi
-}
-
-main "$@"
+# If we get past validation without exiting, exec.
+po_exec


### PR DESCRIPTION
- Adds a command param
- Change number and command to CLI options, so they can each be optionally used, regardless of order or exclusion of the other (what if you want to pass a command like `sh` or `mysql` but don't want to specify a pod number? Option flags are great for this because you don't need to rely on argument number and order.
- Also makes the functions DRY (no repetition in the `po_*` functions now)
- Use man1 help syntax (note that this doesn't actually add man1 doc, but just follows the syntax to make it closer to some standard. Cobra would give us this for free, but this gets us closer).